### PR TITLE
Add debug flag and logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
-print("[DEBUG] main.py module loaded.")
+from src import DEBUG, debug_print
+
+debug_print("[DEBUG] main.py module loaded.")
 #
 # File: main.py (Fully Integrated - Final Correction)
 #
@@ -45,7 +47,7 @@ pygame.init()
 pygame.font.init()
 
 def main():
-    print("[DEBUG] main() function entered.")
+    debug_print("[DEBUG] main() function entered.")
     
     parser = argparse.ArgumentParser()
     parser.add_argument('--exclude-font', type=str, default=None, help='Font to exclude from training (for holdout)')
@@ -159,6 +161,10 @@ def main():
                 )
                 running_error += result['recon_error']
                 error_log[letter].append(result['recon_error'])
+                debug_print(
+                    f"[DEBUG] Cycle {total_cycles}: letter={letter}, error={result['recon_error']:.3f}, "
+                    f"memory_size={len(cognitive_core.memory_manager.memory)}"
+                )
                 time.sleep(0.01)
             avg_error = running_error / reps_per_letter
             print(f"[EPOCH {epoch}] Letter '{letter}': Average recon error = {avg_error:.3f}")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,10 @@
 # This file marks the src directory as a Python package.
+
+# Global debug flag used across modules. Disabled by default.
+DEBUG = False
+
+def debug_print(*args, **kwargs):
+    """Utility wrapper for debug output respecting the DEBUG flag."""
+    if DEBUG:
+        print(*args, **kwargs)
+

--- a/src/cognitive/architecture/learning_utils.py
+++ b/src/cognitive/architecture/learning_utils.py
@@ -3,6 +3,7 @@
 Reusable learning logic for error-driven continual learning, reconstruction diagnostics, and memory management.
 """
 import numpy as np
+from src import DEBUG, debug_print
 
 RECON_ERROR_THRESHOLD = 2.0  # Raised to avoid premature pattern deletion
 
@@ -26,7 +27,7 @@ def process_letter_sample(
     if recon_error > RECON_ERROR_THRESHOLD:
         compositional_layer.reinforce(topk, stroke_sdr, lr=0.01)
         if verbose:
-            print(f"[LEARNING] Hebbian update applied for '{letter}' (recon error: {recon_error:.3f}).")
+            debug_print(f"[LEARNING] Hebbian update applied for '{letter}' (recon error: {recon_error:.3f}).")
     else:
         # Optionally reinforce correct patterns as well (positive reinforcement)
         compositional_layer.reinforce(topk, stroke_sdr, lr=0.005)
@@ -38,13 +39,13 @@ def process_letter_sample(
         if not is_correct:
             cognitive_core.memory_manager.mark_incorrect(compressed, schema)
             if verbose:
-                print(f"[LEARNING] Pattern for '{letter}' marked for relearning (high recon error: {recon_error:.3f}).")
+                debug_print(f"[LEARNING] Pattern for '{letter}' marked for relearning (high recon error: {recon_error:.3f}).")
         else:
             cognitive_core.memory_manager.store(stroke_sdr, letter, error=0, reward=1, verified=True)
             if verbose:
-                print(f"[LEARNING] Pattern for '{letter}' stored as verified (recon error: {recon_error:.3f}).")
+                debug_print(f"[LEARNING] Pattern for '{letter}' stored as verified (recon error: {recon_error:.3f}).")
     if verbose:
-        print(f"Letter '{letter}': Recon error={recon_error:.3f}, Active neurons={len(active_neurons)}")
+        debug_print(f"Letter '{letter}': Recon error={recon_error:.3f}, Active neurons={len(active_neurons)}")
     return {
         'is_correct': recon_error <= RECON_ERROR_THRESHOLD,
         'recon_error': recon_error,
@@ -52,3 +53,4 @@ def process_letter_sample(
         'concept_sdr': concept_sdr,
         'recon_sdr': recon_sdr
     }
+

--- a/src/cognitive/architecture/memory_manager.py
+++ b/src/cognitive/architecture/memory_manager.py
@@ -1,3 +1,5 @@
+from src import DEBUG, debug_print
+
 class MemoryManager:
     """
     Stores only compressed, salient, or schema-level memories. Prunes low-value or redundant data.
@@ -11,22 +13,22 @@ class MemoryManager:
         self.core_concepts = set()  # Set of hashes for core/verified concepts
 
     def store(self, data, context=None, error=0, reward=0, verified=False):
-        print("[DEBUG] Entered store() method")
+        debug_print("[DEBUG] Entered store() method")
         compressed = self.compression.compress(data)
         schema = self.schema.generate(context)
         salience = self.compute_salience(data, error, reward, verified)
         is_core = verified
         mem_hash = self._memory_hash(compressed, schema)
-        print(f"[DEBUG] Attempting to store memory: hash={mem_hash}, is_core={is_core}, salience={salience}, context={context}")
+        debug_print(f"[DEBUG] Attempting to store memory: hash={mem_hash}, is_core={is_core}, salience={salience}, context={context}")
         if is_core:
             self.core_concepts.add(mem_hash)
         if self.is_salient(salience, is_core):
             self.memory.append((compressed, schema, salience, is_core, mem_hash))
             if len(self.memory) > self.max_memories:
                 self.prune()
-            print(f"[MEMORY] Stored: {len(self.memory)} memories (core: {len(self.core_concepts)})")
+            debug_print(f"[MEMORY] Stored: {len(self.memory)} memories (core: {len(self.core_concepts)})")
         else:
-            print(f"[MEMORY] Not stored: salience too low or not core (salience={salience}, is_core={is_core})")
+            debug_print(f"[MEMORY] Not stored: salience too low or not core (salience={salience}, is_core={is_core})")
 
     def compute_salience(self, data, error, reward, verified):
         # High error, high reward, or verified = high salience
@@ -44,7 +46,7 @@ class MemoryManager:
         non_core.sort(key=lambda m: m[2])
         keep = core + non_core[-(self.max_memories - len(core)):]
         self.memory = keep[-self.max_memories:]
-        print(f"[MEMORY] Pruned: {len(self.memory)} memories remain (core: {len(self.core_concepts)})")
+        debug_print(f"[MEMORY] Pruned: {len(self.memory)} memories remain (core: {len(self.core_concepts)})")
 
     def recall(self, query=None):
         # Return best-matching memory (compressed, schema)
@@ -64,4 +66,5 @@ class MemoryManager:
         before = len(self.memory)
         self.memory = [m for m in self.memory if m[4] != mem_hash]
         after = len(self.memory)
-        print(f"[MEMORY] Marked incorrect: removed {before - after} memory (core: {len(self.core_concepts)})")
+        debug_print(f"[MEMORY] Marked incorrect: removed {before - after} memory (core: {len(self.core_concepts)})")
+


### PR DESCRIPTION
## Summary
- introduce global DEBUG flag and helper `debug_print`
- integrate debug logging throughout memory manager, learning utils, and main loop
- log cycle stats and memory size when DEBUG is enabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy/pygame)*

------
https://chatgpt.com/codex/tasks/task_e_68552ae10b40832d899e211bcb0ccb44